### PR TITLE
chore: add `dependabot.yml` to enable automatic PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add a basic `dependabot.yml` so that PRs will be automatically generated to update the versions of the dependencies.